### PR TITLE
Bump aiobotocore

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: rm -f poetry.lock && {{ PYTHON }} -m pip install --no-deps .
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
     - poetry-dynamic-versioning
   run:
     - python >=3.8
-    - aiobotocore ==2.4.0
+    - aiobotocore ==2.7.0
     - boto3 >=1.21.21
     - cryptography >=37.0.0
     - idna >=3.3.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I believe the version of `aiobotocore` for `aioboto3` 12.0 feedstock (2.4.0) doesn't match the pinned version of `aiobotocore` on `aioboto3` [GitHub repo](https://github.com/terrycain/aioboto3/blob/1d7e2d3d1cde0db99306040ac639a8551fb4f8fe/pyproject.toml#L27C1-L27C1) (2.7.0). This PR fixes this.